### PR TITLE
keep a handle to the first worker so that it is still accessible afte…

### DIFF
--- a/solutions/03_durable_agent/solution.ipynb
+++ b/solutions/03_durable_agent/solution.ipynb
@@ -378,6 +378,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f77c899",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "first_worker_taks = worker_task "
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "3e2q9zrqb2t",
    "metadata": {},


### PR DESCRIPTION
keep a handle to the first worker so that it is still accessible after the variable is overwritten

Could probably use a bit of prose around it ("just do this for now - we'll explain in a moment"). And I've done this in the solution - needs to be done in the exercise too.